### PR TITLE
Fix/39 diary edit

### DIFF
--- a/app/src/main/java/com/example/gonggangam/activity/DiaryReadActivity.kt
+++ b/app/src/main/java/com/example/gonggangam/activity/DiaryReadActivity.kt
@@ -1,6 +1,9 @@
 package com.example.gonggangam.activity
 
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Parcelable
 import android.util.Log
@@ -17,6 +20,7 @@ import com.example.gonggangam.diaryService.ReadDiary
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import java.io.ByteArrayOutputStream
 import java.io.Serializable
 
 class DiaryReadActivity : AppCompatActivity() {
@@ -109,7 +113,9 @@ class DiaryReadActivity : AppCompatActivity() {
                     putExtra("year", year)
                     putExtra("month", month)
                     putExtra("day", day)
-                    putExtra("diary", diary as Serializable)
+                    putExtra("diary", diary)
+                    putExtra("state", diary!!.emoji)
+                    putExtra("image", getEmojiImage(diary!!.emoji))
                 })
             }
         }
@@ -122,5 +128,34 @@ class DiaryReadActivity : AppCompatActivity() {
             val intent = Intent(this, AcceptDiaryActivity::class.java)
             startActivity(intent)
         }
+    }
+
+    private fun getEmojiImage(emojiStr: String): ByteArray {
+        val stream = ByteArrayOutputStream()
+        val dId: Int = when (emojiStr) {
+            "depressed" -> R.drawable.emoji_depressed
+            "annoyed" -> R.drawable.emoji_annoyed
+            "boring" -> R.drawable.emoji_boring
+            "complicated" -> R.drawable.emoji_complicated
+            "embarrassing" -> R.drawable.emoji_embarrassing
+            "excited" -> R.drawable.emoji_excited
+            "fun" -> R.drawable.emoji_fun
+            "happy" -> R.drawable.emoji_happy
+            "sad" -> R.drawable.emoji_sad
+            "soso" -> R.drawable.emoji_soso
+            "upset" -> R.drawable.emoji_upset
+            "wonder" -> R.drawable.emoji_wonder
+            else -> R.drawable.emoji_happy
+        }
+
+        val bitmap =
+            (getDrawable(dId) as BitmapDrawable).bitmap
+        val scale = (1024 / bitmap.width.toFloat())
+        val image_w = (bitmap.width * scale).toInt()
+        val image_h = (bitmap.height * scale).toInt()
+        val resize = Bitmap.createScaledBitmap(bitmap, image_w, image_h, true)
+        resize.compress(Bitmap.CompressFormat.JPEG, 100, stream)
+
+        return stream.toByteArray()
     }
 }

--- a/app/src/main/java/com/example/gonggangam/activity/DiaryWriteActivity.kt
+++ b/app/src/main/java/com/example/gonggangam/activity/DiaryWriteActivity.kt
@@ -34,7 +34,6 @@ import com.example.gonggangam.diaryService.DiaryRetrofitInterface
 import com.example.gonggangam.R
 import com.example.gonggangam.databinding.ActivityDiaryWriteBinding
 import com.example.gonggangam.diaryService.ReadDiary
-import com.example.gonggangam.model.Diary
 import com.example.gonggangam.util.BindingAdapter
 import com.example.gonggangam.util.FormDataUtil
 import com.example.gonggangam.util.getRetrofit
@@ -58,6 +57,8 @@ class DiaryWriteActivity : AppCompatActivity() {
 
     private lateinit var imgUri: Uri // diaryImg uri 저장 변수
     var isShare:Boolean = false
+
+    private var diaryEditInfo: ReadDiary? = null
 
     override fun onRequestPermissionsResult(
         requestCode: Int,
@@ -149,21 +150,29 @@ class DiaryWriteActivity : AppCompatActivity() {
     }
 
     private fun saveDiary() {
-        var emojiStr=intent.getStringExtra("state").toString()
-        when (emojiStr) {
-            "우울해요" -> emojiStr = "depressed"
-            "짜증나요" -> emojiStr ="annoyed"
-            "지루해요" -> emojiStr ="boring"
-            "복잡해요" -> emojiStr ="complicated"
-            "창피해요" -> emojiStr ="embarrassing"
-            "설레요" -> emojiStr ="excited"
-            "즐거워요" ->  emojiStr ="fun"
-            "행복해요" -> emojiStr ="happy"
-            "슬퍼요" ->  emojiStr ="sad"
-            "그냥 그래요" ->  emojiStr ="soso"
-            "화나요" ->  emojiStr ="upset"
-            "궁금해요" ->   emojiStr ="wonder"
+        var emojiStr = ""
+
+        if (diaryEditInfo == null) {
+            emojiStr = intent.getStringExtra("state").toString()
+            when (emojiStr) {
+                "우울해요" -> emojiStr = "depressed"
+                "짜증나요" -> emojiStr = "annoyed"
+                "지루해요" -> emojiStr = "boring"
+                "복잡해요" -> emojiStr = "complicated"
+                "창피해요" -> emojiStr = "embarrassing"
+                "설레요" -> emojiStr = "excited"
+                "즐거워요" -> emojiStr = "fun"
+                "행복해요" -> emojiStr = "happy"
+                "슬퍼요" -> emojiStr = "sad"
+                "그냥 그래요" -> emojiStr = "soso"
+                "화나요" -> emojiStr = "upset"
+                "궁금해요" -> emojiStr = "wonder"
+            }
+        } else {
+            emojiStr = diaryEditInfo!!.emoji
         }
+
+
         Log.d("이모지?", emojiStr)
         val year = intent.getIntExtra("year",0)
         val month = intent.getIntExtra("month",0)
@@ -231,14 +240,14 @@ class DiaryWriteActivity : AppCompatActivity() {
     }
 
     private fun loadIntent() {
-        val diary = intent.getSerializableExtra("diary") as ReadDiary?
+        diaryEditInfo = intent.getSerializableExtra("diary") as ReadDiary?
 
-        if (diary != null) {
-            BindingAdapter.loadEmoji(diary.emoji, binding.writeMoodIconIv)
-            binding.writeInputEt.setText(diary.contents)
+        if (diaryEditInfo != null) {
+            BindingAdapter.loadEmoji(diaryEditInfo!!.emoji, binding.writeMoodIconIv)
+            binding.writeInputEt.setText(diaryEditInfo!!.contents)
 
-            if (diary.image != null) {
-                BindingAdapter.loadDiaryImage(diary.image, binding.writeDiaryPhotoIv)
+            if (diaryEditInfo!!.image != null) {
+                BindingAdapter.loadDiaryImage(diaryEditInfo!!.image!!, binding.writeDiaryPhotoIv)
                 binding.writeDiaryPhotoIv.visibility = View.VISIBLE
             }
         }

--- a/app/src/main/java/com/example/gonggangam/diaryService/DiaryResponse.kt
+++ b/app/src/main/java/com/example/gonggangam/diaryService/DiaryResponse.kt
@@ -95,6 +95,13 @@ data class Report (
     @SerializedName("reportContent") val reportContent: String?,
 )
 
+data class DiaryEditRequest(
+    @SerializedName("emoji") val emoji: String,
+    @SerializedName("date") val date: String,
+    @SerializedName("content") val content: String,
+    @SerializedName("shareAgree") val shareAgree: Char
+)
+
 data class Reply (
     @SerializedName("content") val content: String,
     @SerializedName("diaryIdx") val diaryIdx: Int,

--- a/app/src/main/java/com/example/gonggangam/diaryService/DiaryResponse.kt
+++ b/app/src/main/java/com/example/gonggangam/diaryService/DiaryResponse.kt
@@ -6,6 +6,7 @@ import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 import okhttp3.MultipartBody
 import retrofit2.http.Part
+import java.io.Serializable
 
 data class Page (
     val curPage: Int,
@@ -69,7 +70,7 @@ data class ReadDiary(
     @SerializedName("contents") val contents: String,
     @SerializedName("image") val image: String?,
     @SerializedName("answer") val answer: ReadAnswer?
-)
+) : Serializable
 
 data class ReadAnswer(
     @SerializedName("answerIdx") val answerIdx: Int,

--- a/app/src/main/java/com/example/gonggangam/diaryService/DiaryRetrofitInterface.kt
+++ b/app/src/main/java/com/example/gonggangam/diaryService/DiaryRetrofitInterface.kt
@@ -59,6 +59,11 @@ interface DiaryRetrofitInterface {
         @Path ("answerIdx") answerIdx: Int,
     ): Call<BasicResponse>
 
+    @PATCH("app/diarys/{diaryIdx}")
+    fun editDiary(
+        @Path("diaryIdx") diaryIdx: Int,
+        @Body diaryEditBody: DiaryEditRequest
+    ): Call<BasicResponse>
 
     @POST("app/chat")
     fun startChat(


### PR DESCRIPTION
1. 일기 읽기 -> 수정으로 넘기는 과정에서 intent에 누락된 데이터 (이모지 image byteArray, state)를
넘겨주도록 수정하였습니다.

2. 일기 수정 API (PATCH diary)를 추가하여 수정 상태에서는 해당 요청을 날리도록 추가하였습니다.

---

+ 일기 쓰기에서 이모지 수정 버튼을 누르면 오류가 발생합니다. 확인해주시면 감사하겠습니다.